### PR TITLE
Convert dialect from pseudo-object to struct

### DIFF
--- a/gherkin/elixir/lib/gherkin/dialect.ex
+++ b/gherkin/elixir/lib/gherkin/dialect.ex
@@ -1,49 +1,48 @@
 defmodule Gherkin.Dialect do
   @type keywords :: [String.t(), ...]
-  @type t :: pid
+  @type t :: %__MODULE__{
+          and_keywords: keywords,
+          background_keywords: keywords,
+          but_keywords: keywords,
+          examples_keywords: keywords,
+          feature_keywords: keywords,
+          given_keywords: keywords,
+          scenario_keywords: keywords,
+          scenario_outline_keywords: keywords,
+          then_keywords: keywords,
+          when_keywords: keywords
+        }
 
-  @spec and_keywords(t) :: keywords
-  def and_keywords(dialect), do: fetch(dialect, "and")
+  mapping = %{
+    and_keywords: "and",
+    background_keywords: "background",
+    but_keywords: "but",
+    examples_keywords: "examples",
+    feature_keywords: "feature",
+    given_keywords: "given",
+    scenario_keywords: "scenario",
+    scenario_outline_keywords: "scenarioOutline",
+    then_keywords: "then",
+    when_keywords: "when"
+  }
 
-  @spec background_keywords(t) :: keywords
-  def background_keywords(dialect), do: fetch(dialect, "background")
-
-  @spec but_keywords(t) :: keywords
-  def but_keywords(dialect), do: fetch(dialect, "but")
-
-  @spec examples_keywords(t) :: keywords
-  def examples_keywords(dialect), do: fetch(dialect, "examples")
-
-  @spec feature_keywords(t) :: keywords
-  def feature_keywords(dialect), do: fetch(dialect, "feature")
-
-  @spec given_keywords(t) :: keywords
-  def given_keywords(dialect), do: fetch(dialect, "given")
-
-  @spec scenario_keywords(t) :: keywords
-  def scenario_keywords(dialect), do: fetch(dialect, "scenario")
-
-  @spec scenario_outline_keywords(t) :: keywords
-  def scenario_outline_keywords(dialect), do: fetch(dialect, "scenarioOutline")
+  defstruct Map.keys(mapping)
 
   @external_resource dialects_path =
                        :gherkin
                        |> :code.priv_dir()
                        |> Path.join("gherkin-languages.json")
 
-  @spec start_link(String.t()) :: {:ok, pid} | {:error, :unknown_dialect | term}
+  @spec get(String.t()) :: t() | nil
   for {name, spec} <- dialects_path |> File.read!() |> Poison.decode!() do
-    def start_link(name), do: Agent.start_link(fn -> spec end)
+    dialect =
+      mapping
+      |> Stream.map(fn {field, key} -> {field, Map.fetch!(spec, key)} end)
+      |> Enum.into(%{})
+      |> Map.put(:__struct, :__MODULE__)
+
+    def get(unquote(name)), do: unquote(Macro.escape(dialect))
   end
 
-  def start_link(_name), do: {:error, :unknown_dialect}
-
-  @spec then_keywords(t) :: keywords
-  def then_keywords(dialect), do: fetch(dialect, "then")
-
-  @spec when_keywords(t) :: keywords
-  def when_keywords(dialect), do: fetch(dialect, "when")
-
-  @spec fetch(t, String.t()) :: keywords
-  defp fetch(dialect, key), do: Agent.get(dialect, &Map.fetch!(key))
+  def get(_name), do: nil
 end


### PR DESCRIPTION
Why
---

The functionality of Gherkin.Dialect was self-contained and straightforward enough to allow easy conversion to an immutable data structure

How
---

Replace agent process and query functions with struct

Side effects
------------

* Dialect is retrieved with `get/1` instead of `start_link/1`
* The rest of the functions in the module have become fields on the struct