### PR TITLE
Port: Errors

### DIFF
--- a/gherkin/elixir/lib/gherkin/ast/builder.ex
+++ b/gherkin/elixir/lib/gherkin/ast/builder.ex
@@ -343,12 +343,7 @@ defmodule Gherkin.AST.Builder do
   @spec get_location(Token.t(), non_neg_integer) :: Location.t()
   defp get_location(token, column \\ 0)
   defp get_location(token, 0), do: Token.location(token)
-
-  defp get_location(token, column) do
-    token
-    |> Token.location()
-    |> Location.put_column(column)
-  end
+  defp get_location(token, column), do: %{Token.location(token) | column: column}
 
   @spec reject_nils(map) :: map
   defp reject_nils(map) do

--- a/gherkin/elixir/lib/gherkin/dialect.ex
+++ b/gherkin/elixir/lib/gherkin/dialect.ex
@@ -39,7 +39,7 @@ defmodule Gherkin.Dialect do
       mapping
       |> Stream.map(fn {field, key} -> {field, Map.fetch!(spec, key)} end)
       |> Enum.into(%{})
-      |> Map.put(:__struct, :__MODULE__)
+      |> Map.put(:__struct__, __MODULE__)
 
     def get(unquote(name)), do: unquote(Macro.escape(dialect))
   end

--- a/gherkin/elixir/lib/gherkin/errors.ex
+++ b/gherkin/elixir/lib/gherkin/errors.ex
@@ -1,0 +1,80 @@
+defmodule Gherkin.ErrorMessage do
+  alias Gherkin.Location
+
+  @spec t :: String.t()
+
+  @spec new(Location.t(), String.t()) :: t
+  def new(%Location{} = location, message) when is_binary(message),
+    do: "(#{location.line}:#{location.column || 0}): #{message}"
+end
+
+defmodule Gherkin.AST.BuilderError do
+  alias Gherkin.ErrorMessage
+
+  defexception [:location, :message]
+
+  @impl Exception
+  def message(exception), do: ErrorMessage.new(exception.location, exception.message)
+end
+
+defmodule Gherkin.CompositeParserError do
+  alias Gherkin.ErrorMessage
+
+  defexception [:errors, :location]
+
+  @impl Exception
+  def message(exception) do
+    messages = Enum.map_join(exception.errors, "\n", &Exception.message/1)
+    ErrorMessage.new(exception.location, "Parser errors:\n#{messages}")
+  end
+end
+
+defmodule Gherkin.NoSuchLanguageError do
+  alias Gherkin.ErrorMessage
+
+  defexception [:language, :location]
+
+  @impl Exception
+  def message(exception),
+    do: ErrorMessage.new(exception.location, "Language not supported: #{exception.language}")
+end
+
+defmodule Gherkin.UnexpectedEOFError do
+  alias Gherkin.ErrorMessage
+
+  defexception [:expected_token_types, :received_token]
+
+  @impl Exception
+  def message(%{expected_token_types: expected_token_types, received_token: received_token}) do
+    expected = Enum.join(expected_token_types, ", ")
+
+    received_token
+    |> Token.location()
+    |> ErrorMessage.new("unexpected end of file, expected: #{expected}")
+  end
+end
+
+defmodule Gherkin.UnexpectedTokenError do
+  alias Gherkin.ErrorMessage
+
+  defexception [:expected_token_types, :received_token]
+
+  @impl Exception
+  def message(%{expected_token_types: expected_token_types, received_token: received_token}) do
+    expected = Enum.join(expected_token_types, ", ")
+    got = received_token |> Token.token_value() |> String.trim()
+
+    received_token
+    |> location()
+    |> ErrorMessage.new("expected: #{expected}, got '#{got}'")
+  end
+
+  @spec location(Token.t()) :: Location.t()
+  defp location(token) do
+    location = Token.location(received_token)
+
+    if location.column and location.column > 0,
+      do: location,
+      else: %{location | column: Token.line(received_token).indent + 1}
+  end
+end

--- a/gherkin/elixir/lib/gherkin/location.ex
+++ b/gherkin/elixir/lib/gherkin/location.ex
@@ -1,15 +1,5 @@
 defmodule Gherkin.Location do
-  @opaque t :: %__MODULE__{column: non_neg_integer, line: non_neg_integer}
+  @type t :: %__MODULE__{column: non_neg_integer, line: non_neg_integer}
 
   defstruct [:column, :line]
-
-  @spec new(non_neg_integer, non_neg_integer) :: t
-  def new(line, column)
-      when is_integer(line) and line >= 0 and is_integer(column) and column >= 0,
-      do: %__MODULE__{column: column, line: line}
-
-  @spec put_column(t, non_neg_integer) :: t
-  def put_column(%__MODULE__{line: line}, column)
-      when is_integer(column) and column > 0,
-      do: %__MODULE__{column: column, line: line}
 end


### PR DESCRIPTION
Why
---

Build a struct or pseudo-object (module that wraps an agent) in Elixir for every object in the Ruby implementation until Elixir implementation passes Cucumber’s acceptance tests

How
---

* Port Gherkin.AST.BuilderError, Gherkin.CompositeParserError, Gherkin.NoSuchLanguageError, Gherkin.UnexpectedEOFError, and Gherkin.UnexpectedTokenError exceptions
* Simplify Gherkin.Location struct
* Fix typo in Gherkin.Dialect

Side effects
------------

Gherkin.Location functions `new/2` and `put_column/2` removed in favor of basic struct creation and update

Ported objects
--------------

[cucumber/gherkin/ruby/lib/gherkin/errors.rb](https://github.com/verypossible/cucumber/blob/gherkin-elixir/gherkin/ruby/lib/gherkin/errors.rb)

_**Note:** The Gherkin.ParserError and Gherkin.ParserException classes are only base classes and so were not ported._